### PR TITLE
Fixes Viper Tools Release URL

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -289,10 +289,26 @@ jobs:
         shell: bash
         run: echo "TAG_NAME=$(date +v-%Y-%m-%d-%H%M)" >> $GITHUB_ENV
 
+      # use the following action if nightly releases should eventually be deleted
+      # - name: Create nightly release
+      #   if: ${{ github.event.inputs.type != 'stable' }}
+      #   id: create_nightly_release
+      #   uses: viperproject/create-nightly-release@v1
+      #   env:
+      #     # This token is provided by Actions, you do not need to create your own token
+      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      #   with:
+      #     tag_name: ${{ env.TAG_NAME }}
+      #     release_name: Nightly Release ${{ env.TAG_NAME }}
+      #     body: Based on ViperServer release ${{ github.event.inputs.viperserver_tag_name }}
+      #     keep_num: 1 # keep the previous nightly release such that there are always two
+
+      # because e.g. prusti-dev depends on the nightly releases and updates only twice a month to the
+      # latest version, nightly releases should be kept
       - name: Create nightly release
         if: ${{ github.event.inputs.type != 'stable' }}
         id: create_nightly_release
-        uses: viperproject/create-nightly-release@v1
+        uses: actions/create-release@v1
         env:
           # This token is provided by Actions, you do not need to create your own token
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -300,7 +316,8 @@ jobs:
           tag_name: ${{ env.TAG_NAME }}
           release_name: Nightly Release ${{ env.TAG_NAME }}
           body: Based on ViperServer release ${{ github.event.inputs.viperserver_tag_name }}
-          keep_num: 1 # keep the previous nightly release such that there are always two
+          draft: false
+          prerelease: true
 
       - name: Store nightly release upload URL
         if: ${{ github.event.inputs.type != 'stable' }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -126,7 +126,7 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@v1
         with:
-          node-version: '14'
+          node-version: '16' # we use latest node instead of LTS 14 to have the same lockfile version as locally used
 
       - name: Setup Java JDK
         uses: actions/setup-java@v1.4.3
@@ -237,10 +237,11 @@ jobs:
       # locate-java-home and vs-verification-toolbox dependencies (the two non-npm dependencies).
       # this seems related to https://github.com/npm/cli/issues/791
       # the current workaround is to `run npm install` first:
-      - name: Run 'npm install' as a workaround to later being able to package Viper-IDE (ubuntu only)
-        if: startsWith(matrix.os, 'ubuntu')
-        run: npm install
-        working-directory: client
+      # this workaround is only necessary when using node 14
+      # - name: Run 'npm install' as a workaround to later being able to package Viper-IDE (ubuntu only)
+      #   if: startsWith(matrix.os, 'ubuntu')
+      #   run: npm install
+      #   working-directory: client
 
       - name: List all files that will be packaged (ubuntu only)
         if: startsWith(matrix.os, 'ubuntu')

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,9 +35,9 @@ jobs:
       VIPERSERVER_URL: "https://github.com/viperproject/viperserver/releases/download/${{ github.event.inputs.viperserver_tag_name }}/viperserver.jar"
       # we fake a ternary operator `a ? b : c` by using `a && b || c` as mentioned here:
       # https://github.com/actions/runner/issues/409
-      WIN-TOOLS-URL: ${{ github.event.inputs.type == 'nightly' && 'http://viper.ethz.ch/downloads/ViperToolsNightlyWin.zip' || 'http://viper.ethz.ch/downloads/ViperToolsLastReleaseWin.zip' }}
-      LINUX-TOOLS-URL: ${{ github.event.inputs.type == 'nightly' && 'http://viper.ethz.ch/downloads/ViperToolsNightlyLinux.zip' || 'http://viper.ethz.ch/downloads/ViperToolsLastReleaseLinux.zip' }}
-      MAC-TOOLS-URL: ${{ github.event.inputs.type == 'nightly' && 'http://viper.ethz.ch/downloads/ViperToolsNightlyMac.zip' || 'http://viper.ethz.ch/downloads/ViperToolsLastReleaseMac.zip' }}
+      WIN-TOOLS-URL: ${{ github.event.inputs.type == 'nightly' && 'http://viper.ethz.ch/downloads/ViperToolsNightlyWin.zip' || 'http://viper.ethz.ch/downloads/ViperToolsReleaseWin.zip' }}
+      LINUX-TOOLS-URL: ${{ github.event.inputs.type == 'nightly' && 'http://viper.ethz.ch/downloads/ViperToolsNightlyLinux.zip' || 'http://viper.ethz.ch/downloads/ViperToolsReleaseLinux.zip' }}
+      MAC-TOOLS-URL: ${{ github.event.inputs.type == 'nightly' && 'http://viper.ethz.ch/downloads/ViperToolsNightlyMac.zip' || 'http://viper.ethz.ch/downloads/ViperToolsReleaseMac.zip' }}
     steps:
       - name: Install prerequisites
         run: sudo apt-get install curl zip unzip


### PR DESCRIPTION
Adapts the URL from where the stable Viper Tools are pulled from according to @gauravpartha's recommendation. Furthermore, nightly releases are no longer cleaned up. This is important for `prusti-dev` that only updates to the latest nightly release twice a month.