### PR TITLE
Backwards Compatibility of node protocol

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -17,8 +17,8 @@
     },
     "main": "./dist/extension",
     "engines": {
-        "vscode": "^1.45.0",
-        "node": "*"
+        "vscode": "^1.46.0",
+        "node": "^12.8.1"
     },
     "icon": "images/icon_bright_orange_avatar.png",
     "categories": [

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -27,7 +27,7 @@ const ESLintPlugin = require('eslint-webpack-plugin');
 
 /**@type {import('webpack').Configuration}*/
 const config = {
-    target: 'node', // vscode extensions run in a Node.js-context -> https://webpack.js.org/configuration/node/
+    target: 'node12.8', // vscode extensions run in a Node.js-context -> https://webpack.js.org/configuration/node/
     entry: './src/extension.ts', // the entry point of this extension -> https://webpack.js.org/configuration/entry-context/
     output: {
         // the bundle is stored in the 'dist' folder (check package.json) -> https://webpack.js.org/configuration/output/

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -37,9 +37,16 @@ const config = {
         devtoolModuleFilenameTemplate: '../[resource-path]'
     },
     devtool: 'source-map',
-    externals: {
+    externals: [{
         vscode: 'commonjs vscode' // the vscode-module is created on-the-fly and must be excluded. Add other modules that cannot be webpack'edv-> https://webpack.js.org/configuration/externals/
-    },
+    }, function({ context, request }, callback) {
+        if (/^node:/.test(request)) {
+            request = request.replace(/^node:/, "");
+            return callback(null, `commonjs ${request}`);
+        }
+        // Continue without externalizing the import
+        callback();
+    }],
     resolve: {
         // support reading TypeScript and JavaScript files -> https://github.com/TypeStrong/ts-loader
         extensions: ['.ts', '.js']

--- a/server/package.json
+++ b/server/package.json
@@ -9,8 +9,8 @@
     "version": "0.0.1",
     "publisher": "viper-admin",
     "engines": {
-        "vscode": "^1.45.0",
-        "node": "*"
+        "vscode": "^1.46.0",
+        "node": "^12.8.1"
     },
     "devDependencies": {
         "@octokit/rest": "^18.12.0",
@@ -40,7 +40,7 @@
         "yargs": "^17.4.1"
     },
     "scripts": {
-        "clean": "rimraf dist",
+        "clean": "rimraf ../client/server",
         "webpack-production": "webpack --mode production",
         "webpack-development": "webpack --mode development",
         "webpack-development-watch": "webpack --mode development --watch",

--- a/server/webpack.config.js
+++ b/server/webpack.config.js
@@ -23,10 +23,11 @@
 'use strict';
 
 const path = require('path');
+const webpack = require('webpack');
 
 /**@type {import('webpack').Configuration}*/
 const config = {
-    target: 'node', // vscode extensions run in a Node.js-context -> https://webpack.js.org/configuration/node/
+    target: 'node12.8', // vscode extensions run in a Node.js-context -> https://webpack.js.org/configuration/node/
     entry: './src/server.ts', // the entry point of this extension -> https://webpack.js.org/configuration/entry-context/
     output: {
         // the bundle is stored in '../client/server' folder (check package.json) -> https://webpack.js.org/configuration/output/
@@ -36,9 +37,16 @@ const config = {
         devtoolModuleFilenameTemplate: '../[resource-path]'
     },
     devtool: 'source-map',
-    externals: {
+    externals: [{
         vscode: 'commonjs vscode' // the vscode-module is created on-the-fly and must be excluded. Add other modules that cannot be webpack'edv-> https://webpack.js.org/configuration/externals/
-    },
+    }, function({ context, request }, callback) {
+        if (/^node:/.test(request)) {
+            request = request.replace(/^node:/, "");
+            return callback(null, `commonjs ${request}`);
+        }
+        // Continue without externalizing the import
+        callback();
+    }],
     resolve: {
         // support reading TypeScript and JavaScript files -> https://github.com/TypeStrong/ts-loader
         extensions: ['.ts', '.js']


### PR DESCRIPTION
`node:` as prefix is not supported by older node versions and unfortunately webpack does not automatically fix this despite providing an explicit node version as target. This PR, manually drops this prefix from imports.

Fixes #254