### PR TITLE
`"$HOME/Library/Application Support/Viper"` is not a good location for `viperToolsPath`

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -357,7 +357,7 @@
 						"viperToolsPath": {
 							"windows": "%APPDATA%\\Viper\\",
 							"linux": "$HOME/.config/Viper",
-							"mac": "$HOME/Library/Application Support/Code/User/globalStorage/viper-admin.viper"
+							"mac": "$HOME/Library/Application Support/Code/User/globalStorage/viper-admin.viper/Local"
 						},
 						"z3Executable": {
 							"windows": "$viperTools$/z3/bin/z3.exe",

--- a/client/package.json
+++ b/client/package.json
@@ -357,7 +357,7 @@
 						"viperToolsPath": {
 							"windows": "%APPDATA%\\Viper\\",
 							"linux": "$HOME/.config/Viper",
-							"mac": "$HOME/Library/Application Support/Viper"
+							"mac": "$HOME/Library/Application Support/Code/User/globalStorage/viper-admin.viper"
 						},
 						"z3Executable": {
 							"windows": "$viperTools$/z3/bin/z3.exe",

--- a/client/package.json
+++ b/client/package.json
@@ -355,8 +355,8 @@
 					"default": {
 						"v": "674a514867b1",
 						"viperToolsPath": {
-							"windows": "%APPDATA%\\Viper\\",
-							"linux": "$HOME/.config/Viper",
+							"windows": "%APPDATA%\\Roaming\\Code\\User\\globalStorage\\viper-admin.viper\\Local",
+							"linux": "$HOME/.config/Code/User/globalStorage/viper-admin.viper/Local",
 							"mac": "$HOME/Library/Application Support/Code/User/globalStorage/viper-admin.viper/Local"
 						},
 						"z3Executable": {

--- a/client/package.json
+++ b/client/package.json
@@ -355,9 +355,9 @@
 					"default": {
 						"v": "674a514867b1",
 						"viperToolsPath": {
-							"windows": "%APPDATA%\\Roaming\\Code\\User\\globalStorage\\viper-admin.viper\\Local",
-							"linux": "$HOME/.config/Code/User/globalStorage/viper-admin.viper/Local",
-							"mac": "$HOME/Library/Application Support/Code/User/globalStorage/viper-admin.viper/Local"
+							"windows": "%APPDATA%\\Roaming\\Code\\User\\globalStorage\\viper-admin.viper\\Local\\ViperTools",
+							"linux": "$HOME/.config/Code/User/globalStorage/viper-admin.viper/Local/ViperTools",
+							"mac": "$HOME/Library/Application Support/Code/User/globalStorage/viper-admin.viper/Local/ViperTools"
 						},
 						"z3Executable": {
 							"windows": "$viperTools$/z3/bin/z3.exe",


### PR DESCRIPTION
These paths only get relevant for `"buildVersion": "Local"`, which probably nobody uses.

Not sure about the Linux and Windows settings.

Maybe I am misunderstanding this! The Changelog says
> `Local`: uses the Viper Tools located at the path specified as `viperSettings.paths.viperToolsPath`.
So is this path is being created?