### PR TITLE
Makes Boogie Path Optional

### DIFF
--- a/client/src/ViperTools.ts
+++ b/client/src/ViperTools.ts
@@ -13,7 +13,7 @@ import { Log } from './Log';
 import { LogLevel } from './ViperProtocol';
 import { BuildChannel, Settings } from './Settings';
 import { Helper } from './Helper';
-import { toRight, transformRight } from './Either';
+import { transformRight } from './Either';
 
 const buildChannelSubfolderName = "ViperTools";
 

--- a/client/src/ViperTools.ts
+++ b/client/src/ViperTools.ts
@@ -13,6 +13,7 @@ import { Log } from './Log';
 import { LogLevel } from './ViperProtocol';
 import { BuildChannel, Settings } from './Settings';
 import { Helper } from './Helper';
+import { toRight, transformRight } from './Either';
 
 const buildChannelSubfolderName = "ViperTools";
 
@@ -66,10 +67,15 @@ export async function locateViperTools(context: vscode.ExtensionContext): Promis
 
     async function setPermissions(location: Location): Promise<Location> {
         if (Settings.isLinux || Settings.isMac) {
-            const boogiePath = await Settings.getBoogiePath(location);
             const z3Path = await Settings.getZ3Path(location);
             fs.chmodSync(z3Path, '755');
-            fs.chmodSync(boogiePath, '755');
+
+            const boogiePath = await Settings.getBoogiePath(location);
+            // `boogiePath` will be left when the user provided e.g. an empty path.
+            // ignored the error here and only change permissions if it's a valid path
+            transformRight(boogiePath, path => {
+                fs.chmodSync(path, '755');
+            });
         }
         return location;
     }

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -32,7 +32,6 @@ import { VerificationController, TaskType, Task } from './VerificationController
 import { ViperApi } from './ViperApi';
 import { Settings } from './Settings';
 import { Location } from 'vs-verification-toolbox';
-import { Either, isRight, Level, Messages } from './Either';
 
 let autoSaver: Timer;
 

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -68,11 +68,11 @@ async function internalActivate(context: vscode.ExtensionContext): Promise<Viper
     registerContextHandlers(context, location);
     // check whether settings are correct and expected files exist:
     const settingsResult = await Settings.checkAndGetSettings(location);
-    await handleSettingsCheckResult(settingsResult);
+    await Settings.handleSettingsCheckResult(settingsResult);
     State.verificationController = new VerificationController(location);
     fileSystemWatcher = vscode.workspace.createFileSystemWatcher('**/{' + Helper.viperFileEndings.join(",") + "}");
     const startResult = await State.startLanguageServer(context, fileSystemWatcher, location);
-    await handleSettingsCheckResult(startResult);
+    await Settings.handleSettingsCheckResult(startResult);
     State.viperApi = new ViperApi(State.client);
     registerClientHandlers();
     startAutoSaver();
@@ -227,54 +227,6 @@ async function initializeState(location: Location): Promise<void> {
 
     // visually indicate that the IDE is now ready:
     State.statusBarItem.update("ready", Color.READY);
-}
-
-async function handleSettingsCheckResult<R>(res: Either<Messages, R>): Promise<void> {
-    if (isRight(res)) {
-        return; // success, i.e. no warnings and no errors
-    }
-
-    const msgs = res.left;
-    let nofErrors = 0;
-    let nofWarnings = 0;
-    let message = "";
-    msgs.forEach(msg => {
-        switch (msg.level) {
-            case Level.Error:
-                nofErrors++;
-                Log.error(`Settings Error: ${msg.msg}`);
-                break;
-            case Level.Warning:
-                nofWarnings++;
-                Log.log(`Settings Warning: ${msg.msg}`, LogLevel.Info);
-                break;
-            default:
-                nofErrors++; // we simply count it as an error
-                Log.log(`Settings Warning or Error with unknown level '${msg.level}': ${msg.msg}`, LogLevel.Info);
-                break;
-        }
-        message = msg.msg;
-    })
-
-    const countDescription = ((nofErrors > 0 ? ("" + nofErrors + " Error" + (nofErrors > 1 ? "s" : "")) : "") + (nofWarnings > 0 ? (" " + nofWarnings + " Warning" + (nofWarnings > 1 ? "s" : "")) : "")).trim();
-
-    // update status bar
-    Log.log(`${countDescription} detected.`, LogLevel.Info);
-    if (nofErrors > 0) {
-        State.statusBarItem.update(countDescription, Color.ERROR);
-    } else if (nofWarnings > 0) {
-        State.statusBarItem.update(countDescription, Color.WARNING);
-    }
-
-    // we can display one message, if there are more we redirect users to the output view:
-    if (nofErrors + nofWarnings > 1) {
-        message = "see View->Output->Viper";
-    }
-    Log.hint(`${countDescription}: ${message}`, `Viper Settings`, true, true);
-    if (nofErrors > 0) {
-        // abort only in the case of errors
-        throw new Error(`Problems in Viper Settings detected`);
-    }
 }
 
 function registerContextHandlers(context: vscode.ExtensionContext, location: Location): void {


### PR DESCRIPTION
This PR allows to specify an empty Boogie path when Boogie is not needed (as indicated by error messages). Viper-IDE correctly skips all checks whether the specified binary exists and is executable. However, Viper-IDE will display an error message as soon as the Boogie path is passed to a verification backend such that these configuration issues still get detected. 

Fixes #328