### PR TITLE
Add default Java binary location

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -399,7 +399,7 @@
 					"type": "object",
 					"default": {
 						"v": "674a514867b1",
-						"javaBinary": "",
+						"javaBinary": "java",
 						"customArguments": "-Xmx2048m -Xss16m -cp $backendPaths$ -server $mainMethod$",
 						"cwd": ""
 					},


### PR DESCRIPTION
This PR uses `java` from the current environment as a reasonable default for the JRE location. 

We are using equivalent logic for [Motoko formal verification](https://github.com/dfinity/vscode-motoko/pull/81) (which depends on viper-ide), so perhaps it makes sense to include this here to simplify the initial setup for everyone. 
