### PR TITLE
Hide Status Bar when no Viper file is open

### DIFF
--- a/client/src/ExtensionState.ts
+++ b/client/src/ExtensionState.ts
@@ -77,7 +77,7 @@ export class State {
 
     public static initializeStatusBar(context: vscode.ExtensionContext): void {
         this.statusBarItem = new StatusBar(10, context);
-        this.statusBarItem.update("Hello from Viper", Color.READY).show();
+        this.statusBarItem.update("Hello from Viper", Color.READY);
 
         this.abortButton = new StatusBar(11, context);
         this.abortButton.setCommand("viper.stopVerification");
@@ -87,10 +87,30 @@ export class State {
 
         this.backendStatusBar = new StatusBar(12, context);
         this.backendStatusBar.setCommand("viper.selectBackend");
-        this.backendStatusBar.show();
-
+        
+        this.showViperStatusBarItems();
         
         this.diagnosticCollection = vscode.languages.createDiagnosticCollection();
+    }
+
+    public static showViperStatusBarItems():  void {
+        if (this.statusBarItem) {
+            this.statusBarItem.show();
+        }
+        // we do not interfere with statusBarProgress and abortButton here, because they are only visible while verifying a file
+        if (this.backendStatusBar) {
+            this.backendStatusBar.show();
+        }
+    }
+
+    public static hideViperStatusBarItems(): void {
+        if (this.statusBarItem) {
+            this.statusBarItem.hide();
+        }
+        // we do not interfere with statusBarProgress and abortButton here, because they are only visible while verifying a file
+        if (this.backendStatusBar) {
+            this.backendStatusBar.hide();
+        }
     }
 
     public static hideProgress(): void {

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -256,6 +256,8 @@ function registerContextHandlers(context: vscode.ExtensionContext, location: Loc
                 const uri = editor.document.uri;
                 if (Helper.isViperSourceFile(uri)) {
                     const fileState = State.setLastActiveFile(uri, editor);
+                    // show status bar items (in case they were hidden)
+                    State.showViperStatusBarItems();
                     if (fileState) {
                         if (!fileState.verified) {
                             Log.log("The active text editor changed, consider reverification of " + fileState.name(), LogLevel.Debug);
@@ -265,6 +267,9 @@ function registerContextHandlers(context: vscode.ExtensionContext, location: Loc
                         }
                         Log.log("Active viper file changed to " + fileState.name(), LogLevel.Info);
                     }
+                } else {
+                    // hide status bar items (in case they are shown):
+                    State.hideViperStatusBarItems();
                 }
             }
         } catch (e) {


### PR DESCRIPTION
This PR hides and shows Viper's status bar items whenever the currently open file changes