### PR TITLE
Bumped Z3 version

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,7 @@ on:
       z3_version:
         description: 'Z3 version that should be downloaded and included in a release'
         required: true
-        default: '4.8.6'
+        default: '4.8.7'
       tag_name:
         description: 'Tag name for stable release.'
         required: true


### PR DESCRIPTION
Silicon and Carbon are both tested with Z3 4.8.7, so (either for this release or the next one) we should also bundle Z3 4.8.7 with Viper IDE.